### PR TITLE
[SDPA-3455] applying permission check to content moderation

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=eade89171ec349c8a49c47cf94820b1724f033bf
+# export GH_COMMIT=COMMIT_SHA
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/src/Access/ModerationStateAccess.php
+++ b/src/Access/ModerationStateAccess.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\tide_site_restriction\Access;
+
+use Drupal\content_moderation\ModerationInformationInterface;
+use Drupal\content_moderation\StateTransitionValidation;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\tide_site_restriction\Helper;
+use Drupal\user\Entity\User;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Extends StateTransitionValidation's logic.
+ */
+class ModerationStateAccess extends StateTransitionValidation implements ContainerInjectionInterface {
+
+  /**
+   * Tide site restriction helper.
+   *
+   * @var \Drupal\tide_site_restriction\Helper
+   */
+  protected $helper;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ModerationInformationInterface $moderation_info, Helper $helper) {
+    parent::__construct($moderation_info);
+    $this->helper = $helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('content_moderation.moderation_information'),
+      $container->get('tide_site_restriction.helper')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValidTransitions(ContentEntityInterface $entity, AccountInterface $account) {
+    $results = parent::getValidTransitions($entity, $account);
+    $user = User::load($account->id());
+    $sites = $this->helper->getUserSites($user);
+    // Another wrapped logic on the top of its parent.
+    return array_filter($results, function () use ($entity, $sites, $account) {
+      if ($this->helper->canBypassRestriction($account)) {
+        return TRUE;
+      }
+      // If we were in node.add page returns its parent result.
+      if ($entity->isNew()) {
+        return TRUE;
+      }
+      return $this->helper->hasEntitySitesAccess($entity, $sites);
+    });
+  }
+
+}

--- a/src/TideSiteRestrictionServiceProvider.php
+++ b/src/TideSiteRestrictionServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\tide_site_restriction;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\Core\DependencyInjection\ServiceProviderInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class TideSiteRestrictionServiceProvider.
+ *
+ * Altering Drupal Core behavior.
+ *
+ * @package Drupal\tide_site_restriction
+ */
+class TideSiteRestrictionServiceProvider extends ServiceProviderBase implements ServiceProviderInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    $definition = $container->getDefinition('content_moderation.state_transition_validation');
+    $definition->setClass('Drupal\tide_site_restriction\Access\ModerationStateAccess')
+      ->addArgument(new Reference('tide_site_restriction.helper'));
+  }
+
+}

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -165,6 +165,8 @@ function tide_site_restriction_form_views_exposed_form_alter(&$form, FormStateIn
 }
 
 /**
+ * Extends content_moderation_entity_view.
+ *
  * Implements hook_entity_view_alter().
  */
 function tide_site_restriction_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
@@ -173,6 +175,7 @@ function tide_site_restriction_entity_view_alter(array &$build, EntityInterface 
     $account = Drupal::service('current_user');
     /** @var \Drupal\tide_site_restriction\Helper $helper */
     $helper = Drupal::service('tide_site_restriction.helper');
+    // Do nothing if the user could bypass the permission check.
     if ($helper->canBypassRestriction($account)) {
       return;
     }
@@ -183,17 +186,31 @@ function tide_site_restriction_entity_view_alter(array &$build, EntityInterface 
       $moderation_state = $entity->get('moderation_state')->value;
       if ($moderation_state) {
         $workflow = $contentModerationInfo->getWorkflowForEntity($entity);
+        // Do nothing if the content published, lets content_moderation module
+        // take care of the rest of logic.
         if ($workflow->getTypePlugin()->getState($moderation_state)->isPublishedState()) {
           return;
         }
+        // Do nothing if current user has approver role.
+        // Notes:
+        // 1. If the entity had been published, the `content_moderation_control`
+        // Form will be hide from the entity view by default, this behavior
+        // could not be altered. The user needs to go to /edit page for changing
+        // the moderation stats.
+        // 2. Otherwise, the approver could do anything they can do based on the
+        // permissions that tide_site_restriction defined.
         if (in_array('approver', $account->getRoles())) {
           return;
         }
+        // Do nothing if current moderation state is draft.
+        // In this circumstance, editor, who has permission to change the
+        // moderation state, can only change the entity to `needs to review`.
         if ($moderation_state == 'draft') {
           return;
         }
       }
     }
+    // Otherwise, unset the form from the entity view.
     unset($build['content_moderation_control']);
   }
 }

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -16,7 +16,6 @@ use Drupal\user\UserInterface;
 use Drupal\views\Plugin\views\cache\CachePluginBase;
 use Drupal\views\ViewExecutable;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 
 /**
  * Implements hook_entity_field_access().
@@ -161,56 +160,5 @@ function tide_site_restriction_form_views_exposed_form_alter(&$form, FormStateIn
         ];
       }
     }
-  }
-}
-
-/**
- * Extends content_moderation_entity_view.
- *
- * Implements hook_entity_view_alter().
- */
-function tide_site_restriction_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
-  if (isset($build['content_moderation_control'])) {
-    /** @var \Drupal\Core\Session\AccountProxyInterface $account */
-    $account = Drupal::service('current_user');
-    /** @var \Drupal\tide_site_restriction\Helper $helper */
-    $helper = Drupal::service('tide_site_restriction.helper');
-    // Do nothing if the user could bypass the permission check.
-    if ($helper->canBypassRestriction($account)) {
-      return;
-    }
-    $user_sites = $helper->getUserSites(User::load($account->id()));
-    if ($helper->hasEntitySitesAccess($entity, $user_sites)) {
-      /** @var \Drupal\content_moderation\ModerationInformation $contentModerationInfo */
-      $contentModerationInfo = \Drupal::service('content_moderation.moderation_information');
-      $moderation_state = $entity->get('moderation_state')->value;
-      if ($moderation_state) {
-        $workflow = $contentModerationInfo->getWorkflowForEntity($entity);
-        // Do nothing if the content published, lets content_moderation module
-        // take care of the rest of logic.
-        if ($workflow->getTypePlugin()->getState($moderation_state)->isPublishedState()) {
-          return;
-        }
-        // Do nothing if current user has approver role.
-        // Notes:
-        // 1. If the entity had been published, the `content_moderation_control`
-        // Form will be hide from the entity view by default, this behavior
-        // could not be altered. The user needs to go to /edit page for changing
-        // the moderation stats.
-        // 2. Otherwise, the approver could do anything they can do based on the
-        // permissions that tide_site_restriction defined.
-        if (in_array('approver', $account->getRoles())) {
-          return;
-        }
-        // Do nothing if current moderation state is draft.
-        // In this circumstance, editor, who has permission to change the
-        // moderation state, can only change the entity to `needs to review`.
-        if ($moderation_state == 'draft') {
-          return;
-        }
-      }
-    }
-    // Otherwise, unset the form from the entity view.
-    unset($build['content_moderation_control']);
   }
 }

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -16,6 +16,7 @@ use Drupal\user\UserInterface;
 use Drupal\views\Plugin\views\cache\CachePluginBase;
 use Drupal\views\ViewExecutable;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 
 /**
  * Implements hook_entity_field_access().
@@ -160,5 +161,39 @@ function tide_site_restriction_form_views_exposed_form_alter(&$form, FormStateIn
         ];
       }
     }
+  }
+}
+
+/**
+ * Implements hook_entity_view_alter().
+ */
+function tide_site_restriction_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+  if (isset($build['content_moderation_control'])) {
+    /** @var \Drupal\Core\Session\AccountProxyInterface $account */
+    $account = Drupal::service('current_user');
+    /** @var \Drupal\tide_site_restriction\Helper $helper */
+    $helper = Drupal::service('tide_site_restriction.helper');
+    if ($helper->canBypassRestriction($account)) {
+      return;
+    }
+    $user_sites = $helper->getUserSites(User::load($account->id()));
+    if ($helper->hasEntitySitesAccess($entity, $user_sites)) {
+      /** @var \Drupal\content_moderation\ModerationInformation $contentModerationInfo */
+      $contentModerationInfo = \Drupal::service('content_moderation.moderation_information');
+      $moderation_state = $entity->get('moderation_state')->value;
+      if ($moderation_state) {
+        $workflow = $contentModerationInfo->getWorkflowForEntity($entity);
+        if ($workflow->getTypePlugin()->getState($moderation_state)->isPublishedState()) {
+          return;
+        }
+        if (in_array('approver', $account->getRoles())) {
+          return;
+        }
+        if ($moderation_state == 'draft') {
+          return;
+        }
+      }
+    }
+    unset($build['content_moderation_control']);
   }
 }


### PR DESCRIPTION
## JIRA
https://digital-engagement.atlassian.net/browse/SDPA-3455

## Changes
1. alter `content_moderation.state_transition_validation` service to provide a custom service.

https://github.com/dpc-sdp/content-vic-gov-au/pull/781
https://github.com/dpc-sdp/tide_core/pull/125