### PR TITLE
[SDPA-4514] Fixes an issue in tide_site_restriction_node_grants_alter()

### DIFF
--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -208,6 +208,16 @@ function tide_site_restriction_node_grants(AccountInterface $account, $op) {
  * Implements hook_node_grants_alter().
  */
 function tide_site_restriction_node_grants_alter(&$grants, AccountInterface $account, $op) {
+  /** @var \Drupal\tide_site_restriction\Helper $site_restriction_helper */
+  $site_restriction_helper = \Drupal::service('tide_site_restriction.helper');
+  // If the user could bypass the restriction, we provide an opportunity for
+  // other modules to alter the grants.
+  if ($site_restriction_helper->canBypassRestriction($account) === TRUE) {
+    return $grants;
+  }
+
+  // If the user could not bypass the restriction, it should respect the
+  // tide_site_restriction rules only.
   foreach ($grants as $realm => $gid) {
     // Other modules should respect to the tide_site_restriction module.
     if ($realm != 'tide_site_restriction') {


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4514

### Issue
site_admin users cannot see unpublished nodes.

for fixing the issue, we update `tide_site_restriction_node_grants_alter` by adding a wrapper to check if the user can bypass the permission check, if they could, we will let other modules to alter the result. 

### Changes
update tide_site_restriction_node_grants_alter 
   - add a wrapper `$site_restriction_helper->canBypassRestriction($account) === FALSE`
   - and comments