### PR TITLE
apply restrictions to entity clone

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "^1.6.0",
+        "dpc-sdp/tide_core": "dev-feature/SDPA-4755--content-cloning as 1.6.14",
         "dpc-sdp/tide_site": "^1.4.0",
         "dpc-sdp/tide_publication": "^1.0.0",
         "drupal/select2": "1.7",

--- a/src/EventSubscriber/TideSiteRestrictionEntityClone.php
+++ b/src/EventSubscriber/TideSiteRestrictionEntityClone.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\tide_site_restriction\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\entity_clone\Event\EntityCloneEvent;
+use Drupal\node\NodeInterface;
+use Drupal\tide_site_restriction\Helper;
+use Drupal\user\Entity\User;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class TideSiteRestrictionEntityClone.
+ */
+class TideSiteRestrictionEntityClone implements EventSubscriberInterface, ContainerAwareInterface {
+
+  use ContainerAwareTrait;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * The tide restriction helper class.
+   *
+   * @var \Drupal\tide_site_restriction\Helper
+   */
+  protected $helper;
+
+  /**
+   * The term entity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface|mixed|object
+   */
+  protected $termStorage;
+
+  /**
+   * Constructs a TideSiteRestrictionEntityClone class.
+   */
+  public function __construct(AccountProxy $currentUser, Helper $helper, EntityTypeManager $entityTypeManager) {
+    $this->currentUser = $currentUser;
+    $this->helper = $helper;
+    $this->termStorage = $entityTypeManager->getStorage('taxonomy_term');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'entity_clone.post_clone' => 'postCloneUpdate',
+    ];
+  }
+
+  /**
+   * Sets default values to site fields.
+   */
+  public function postCloneUpdate(EntityCloneEvent $event) {
+    $cloned_entity = $event->getClonedEntity();
+    if ($cloned_entity instanceof NodeInterface) {
+      if (!$this->helper->canBypassRestriction($this->currentUser)) {
+        $sites = $this->helper->getUserSites(User::load($this->currentUser->id()));
+        $random_site = reset($sites);
+        $term = $this->termStorage->loadParents($random_site);
+        if (empty($term)) {
+          $primary_site = $random_site;
+        }
+        else {
+          $primary_site = $term->id();
+        }
+        $cloned_entity->field_node_primary_site->target_id = $primary_site;
+        $cloned_entity->set('field_node_site', []);
+        foreach ($sites as $site) {
+          $cloned_entity->field_node_site[] = $site;
+        }
+      }
+      $cloned_entity->save();
+    }
+  }
+
+}

--- a/src/EventSubscriber/TideSiteRestrictionRouterAlter.php
+++ b/src/EventSubscriber/TideSiteRestrictionRouterAlter.php
@@ -23,11 +23,6 @@ class TideSiteRestrictionRouterAlter extends RouteSubscriberBase {
     if ($route = $collection->get('entity.node.entity_hierarchy_reorder')) {
       $route->setRequirement('_custom_access', '\Drupal\tide_site_restriction\EventSubscriber\TideSiteRestrictionRouterAlter::childPageAccess');
     }
-    foreach (\Drupal::service('entity_type.manager')->getDefinitions() as $entity_type_id => $entity_type) {
-      if ($route = $collection->get("entity.$entity_type_id.clone_form")) {
-        $route->setRequirement('_custom_access', '\Drupal\tide_site_restriction\EventSubscriber\TideSiteRestrictionRouterAlter::childPageAccess');
-      }
-    }
   }
 
   /**

--- a/src/EventSubscriber/TideSiteRestrictionRouterAlter.php
+++ b/src/EventSubscriber/TideSiteRestrictionRouterAlter.php
@@ -23,6 +23,11 @@ class TideSiteRestrictionRouterAlter extends RouteSubscriberBase {
     if ($route = $collection->get('entity.node.entity_hierarchy_reorder')) {
       $route->setRequirement('_custom_access', '\Drupal\tide_site_restriction\EventSubscriber\TideSiteRestrictionRouterAlter::childPageAccess');
     }
+    foreach (\Drupal::service('entity_type.manager')->getDefinitions() as $entity_type_id => $entity_type) {
+      if ($route = $collection->get("entity.$entity_type_id.clone_form")) {
+        $route->setRequirement('_custom_access', '\Drupal\tide_site_restriction\EventSubscriber\TideSiteRestrictionRouterAlter::childPageAccess');
+      }
+    }
   }
 
   /**

--- a/tests/behat/features/entity_clone.feature
+++ b/tests/behat/features/entity_clone.feature
@@ -22,27 +22,26 @@ Feature: applying restriction to entity clone module.
     And users:
       | name        | status | uid    | mail                    | pass         | field_user_site | roles  |
       | test.editor |      1 | 999999 | test.editor@example.com | L9dx9IJz3'M* | Test Section 11 | Editor |
+      | test.admin |      1 | 999995 | site.admin@example.com | L9dx9IJz2'M* | Test Section 11 | Site Admin |
 
     And test content:
       | title       | path       | moderation_state | uuid                                | field_node_site                                             | field_node_primary_site | nid     | field_topic  |
       | [TEST] LP 1 | /test-lp-1 | published        | 99999999-aaaa-bbbb-ccc-000000000001 | Test Site 1, Test Section 11                                | Test Site 1             | 999999  | Test topic 1 |
       | [TEST] LP 2 | /test-lp-2 | published        | 99999999-aaaa-bbbb-ccc-000000000002 | Test Site 1, Test Section 11, Test Section 12               | Test Site 1             | 999998  | Test topic 2 |
       | [TEST] LP 3 | /test-lp-3 | published        | 99999999-aaaa-bbbb-ccc-000000000003 | Test Site 2                                                 | Test Site 2             | 999997  | Test topic 3 |
-    When I am logged in as "test.editor"
+    Given I am logged in as "test.editor"
     Then I go to "/node/999999/edit"
     Then I should get a 200 HTTP response
-    Then save screenshot
-    Then I should see an "input#edit-field-node-site-10010" element
-    And I should see an "input#edit-field-node-site-10011" element
-    And I should see an "input#edit-field-node-site-10014" element
-    And I fill in "Title" with "Bibendum Pharetra Inceptos"
-    And I fill in "Summary" with "Cras Tristique Risus"
-    And I fill in "Topic" with "Test topic 1 (10017)"
-    And I select "Draft" from "Change to"
     When I go to "/entity_clone/node/999999"
     Then I should get a 200 HTTP response
     When I go to "/entity_clone/node/999998"
     Then I should get a 200 HTTP response
     When I go to "/entity_clone/node/999997"
     Then I should get a 404 HTTP response
-
+    Given I am logged in as "test.admin"
+    When I go to "/entity_clone/node/999999"
+    Then I should get a 200 HTTP response
+    When I go to "/entity_clone/node/999998"
+    Then I should get a 200 HTTP response
+    When I go to "/entity_clone/node/999997"
+    Then I should get a 200 HTTP response

--- a/tests/behat/features/entity_clone.feature
+++ b/tests/behat/features/entity_clone.feature
@@ -1,0 +1,48 @@
+@suggest
+Feature: applying restriction to entity clone module.
+
+  Ensure that site selector widget meets the expected requirements.
+
+  @api @suggest
+  Scenario: editors can access entity clone that site-admin user created.
+    Given sites terms:
+      | name                 | parent          | tid   | uuid                                  |
+      | Test Site 1          | 0               | 10010 | 11dede11-10c0-111e1-1100-000000000031 |
+      | Test Section 11      | Test Site 1     | 10011 | 11dede11-10d0-111e1-1100-000000000032 |
+      | Test Section 12      | Test Site 1     | 10014 | 11dede11-10g0-111e1-1100-000000000035 |
+      | Test Site 2          | 0               | 10015 | 11dede11-10h0-111e1-1100-000000000036 |
+      | Test Site 3          | 0               | 10016 | 11dede11-10i0-111e1-1100-000000000037 |
+
+    And topic terms:
+      | name         | parent | tid   |
+      | Test topic 1 | 0      | 10017 |
+      | Test topic 2 | 0      | 10018 |
+      | Test topic 3 | 0      | 10019 |
+
+    And users:
+      | name        | status | uid    | mail                    | pass         | field_user_site | roles  |
+      | test.editor |      1 | 999999 | test.editor@example.com | L9dx9IJz3'M* | Test Section 11 | Editor |
+
+    And test content:
+      | title       | path       | moderation_state | uuid                                | field_node_site                                             | field_node_primary_site | nid     | field_topic  |
+      | [TEST] LP 1 | /test-lp-1 | published        | 99999999-aaaa-bbbb-ccc-000000000001 | Test Site 1, Test Section 11                                | Test Site 1             | 999999  | Test topic 1 |
+      | [TEST] LP 2 | /test-lp-2 | published        | 99999999-aaaa-bbbb-ccc-000000000002 | Test Site 1, Test Section 11, Test Section 12               | Test Site 1             | 999998  | Test topic 2 |
+      | [TEST] LP 3 | /test-lp-3 | published        | 99999999-aaaa-bbbb-ccc-000000000003 | Test Site 2                                                 | Test Site 2             | 999997  | Test topic 3 |
+    When I am logged in as "test.editor"
+    Then I go to "/node/999999/edit"
+    Then I should get a 200 HTTP response
+    Then save screenshot
+    Then I should see an "input#edit-field-node-site-10010" element
+    And I should see an "input#edit-field-node-site-10011" element
+    And I should see an "input#edit-field-node-site-10014" element
+    And I fill in "Title" with "Bibendum Pharetra Inceptos"
+    And I fill in "Summary" with "Cras Tristique Risus"
+    And I fill in "Topic" with "Test topic 1 (10017)"
+    And I select "Draft" from "Change to"
+    When I go to "/entity_clone/node/999999"
+    Then I should get a 200 HTTP response
+    When I go to "/entity_clone/node/999998"
+    Then I should get a 200 HTTP response
+    When I go to "/entity_clone/node/999997"
+    Then I should get a 404 HTTP response
+

--- a/tests/behat/features/entity_clone.feature
+++ b/tests/behat/features/entity_clone.feature
@@ -25,19 +25,22 @@ Feature: applying restriction to entity clone module.
       | test.admin |      1 | 999995 | site.admin@example.com | L9dx9IJz2'M* | Test Section 11 | Site Admin |
 
     And test content:
-      | title       | path       | moderation_state | uuid                                | field_node_site                                             | field_node_primary_site | nid     | field_topic  |
-      | [TEST] LP 1 | /test-lp-1 | published        | 99999999-aaaa-bbbb-ccc-000000000001 | Test Site 1, Test Section 11                                | Test Site 1             | 999999  | Test topic 1 |
-      | [TEST] LP 2 | /test-lp-2 | published        | 99999999-aaaa-bbbb-ccc-000000000002 | Test Site 1, Test Section 11, Test Section 12               | Test Site 1             | 999998  | Test topic 2 |
-      | [TEST] LP 3 | /test-lp-3 | published        | 99999999-aaaa-bbbb-ccc-000000000003 | Test Site 2                                                 | Test Site 2             | 999997  | Test topic 3 |
+      | title       | path       | moderation_state | uuid                                | field_node_site                                             | field_node_primary_site | nid     | field_topic  | author      |
+      | [TEST] LP 1 | /test-lp-1 | published        | 99999999-aaaa-bbbb-ccc-000000000001 | Test Site 1, Test Section 11                                | Test Site 1             | 999999  | Test topic 1 | test.editor |
+      | [TEST] LP 2 | /test-lp-2 | published        | 99999999-aaaa-bbbb-ccc-000000000002 | Test Site 1, Test Section 11, Test Section 12               | Test Site 1             | 999998  | Test topic 2 | test.editor |
+      | [TEST] LP 3 | /test-lp-3 | published        | 99999999-aaaa-bbbb-ccc-000000000003 | Test Site 2                                                 | Test Site 2             | 999997  | Test topic 3 | test.admin  |
     Given I am logged in as "test.editor"
     Then I go to "/node/999999/edit"
     Then I should get a 200 HTTP response
+    Then I should see the link "Clone"
     When I go to "/entity_clone/node/999999"
     Then I should get a 200 HTTP response
     When I go to "/entity_clone/node/999998"
     Then I should get a 200 HTTP response
     When I go to "/entity_clone/node/999997"
     Then I should get a 404 HTTP response
+    When I go to "/node/999997"
+    Then I should not see the link "Clone"
     Given I am logged in as "test.admin"
     When I go to "/entity_clone/node/999999"
     Then I should get a 200 HTTP response

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -40,7 +40,7 @@ function tide_site_restriction_entity_access(EntityInterface $entity, $operation
   if (!in_array($entity->getEntityTypeId(), $site_restriction_helper->getSupportedEntityTypes())) {
     return AccessResult::neutral()->addCacheableDependency($entity);
   }
-  if ($account->isAuthenticated() && in_array($operation, ['update', 'delete'])) {
+  if ($account->isAuthenticated() && in_array($operation, ['update', 'delete', 'clone'])) {
     $access_result = tide_site_compute_access($account, $entity, $site_restriction_helper);
     return $access_result;
   }

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -41,10 +41,10 @@ function tide_site_restriction_entity_access(EntityInterface $entity, $operation
     return AccessResult::neutral()->addCacheableDependency($entity);
   }
   if ($account->isAuthenticated() && in_array($operation, [
-      'update',
-      'delete',
-      'clone',
-    ])) {
+    'update',
+    'delete',
+    'clone',
+  ])) {
     $access_result = tide_site_compute_access($account, $entity, $site_restriction_helper);
     return $access_result;
   }

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -40,7 +40,11 @@ function tide_site_restriction_entity_access(EntityInterface $entity, $operation
   if (!in_array($entity->getEntityTypeId(), $site_restriction_helper->getSupportedEntityTypes())) {
     return AccessResult::neutral()->addCacheableDependency($entity);
   }
-  if ($account->isAuthenticated() && in_array($operation, ['update', 'delete', 'clone'])) {
+  if ($account->isAuthenticated() && in_array($operation, [
+      'update',
+      'delete',
+      'clone',
+    ])) {
     $access_result = tide_site_compute_access($account, $entity, $site_restriction_helper);
     return $access_result;
   }

--- a/tide_site_restriction.services.yml
+++ b/tide_site_restriction.services.yml
@@ -8,3 +8,8 @@ services:
     class: Drupal\tide_site_restriction\EventSubscriber\TideSiteRestrictionRouterAlter
     tags:
       - { name: event_subscriber }
+  tide_site_restriction.entity_clone_event_subscriber:
+    class: Drupal\tide_site_restriction\EventSubscriber\TideSiteRestrictionEntityClone
+    arguments: [ '@current_user','@tide_site_restriction.helper','@entity_type.manager', ]
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
### Changes
1. update `src/EventSubscriber/TideSiteRestrictionRouterAlter.php` to apply the restriction to the entity clone.
2. update `tide_site_restriction.module` to apply the restriction to `clone` operation.
3. update test

dpc-sdp/content-vic-gov-au#1000
https://github.com/dpc-sdp/tide_core/pull/193
dpc-sdp/dev-tools#45