### PR TITLE
[SDPA-5317] All users need to be assigned a site.

### DIFF
--- a/config/install/field.field.user.user.field_user_site.yml
+++ b/config/install/field.field.user.user.field_user_site.yml
@@ -15,7 +15,7 @@ entity_type: user
 bundle: user
 label: 'Site Restriction'
 description: 'This user will only have editorial access to content belonging to the selected Sites and Sub-sites. This field is optional for roles permitted to bypass site restrictions. See the permissions sub-system for the roles that can bypass.'
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/tide_site_restriction.install
+++ b/tide_site_restriction.install
@@ -50,3 +50,14 @@ function tide_site_restriction_install() {
     $role->save();
   }
 }
+
+/**
+ * Changes user.field_user_site field to `required` field.
+ */
+function tide_site_restriction_update_8001() {
+  $field = \Drupal::entityTypeManager()
+    ->getStorage('field_config')
+    ->load('user.user.field_user_site');
+  $field->setRequired(TRUE);
+  $field->save();
+}

--- a/tide_site_restriction.install
+++ b/tide_site_restriction.install
@@ -143,7 +143,7 @@ function tide_site_restriction_update_8001() {
 /**
  * Changes user.field_user_site field to `required` field.
  */
-function tide_site_restriction_update_8001() {
+function tide_site_restriction_update_8002() {
   $field = \Drupal::entityTypeManager()
     ->getStorage('field_config')
     ->load('user.user.field_user_site');

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -18,7 +18,6 @@ use Drupal\views\ViewExecutable;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\node\Entity\Node;
 use Drupal\tide_site_restriction\Helper;
-use Drupal\user\Entity\Role;
 use Drupal\node\Entity\NodeType;
 
 /**
@@ -28,7 +27,6 @@ function tide_site_restriction_entity_field_access($operation, FieldDefinitionIn
   if ($field_definition->getName() == 'field_user_site' && $operation == 'edit') {
     return $account->hasPermission('administer site restriction') ? AccessResult::allowed() : AccessResult::forbidden();
   }
-
   return AccessResult::neutral();
 }
 
@@ -250,78 +248,6 @@ function tide_site_compute_access(AccountInterface $account, EntityInterface $en
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function tide_site_restriction_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if (isset($form['field_user_site']) && $form['field_user_site']['#access']) {
-    $roles = Role::loadMultiple();
-    $states = [];
-    foreach ($roles as $role_id => $role) {
-      if ($role->hasPermission('bypass node access') || $role->hasPermission('administer nodes') || $role->hasPermission('bypass site restriction')) {
-        $states[] = [
-          [':input[name="roles[' . $role_id . ']"]' => ['checked' => TRUE]],
-          'or',
-          // We have drupal/role_delegation dependency, so need to check
-          // role_change name.
-          [':input[name="role_change[' . $role_id . ']"]' => ['checked' => TRUE]],
-          'or',
-        ];
-      }
-    }
-    $results = [];
-    if ($states) {
-      foreach ($states as $state) {
-        $results = array_merge($results, $state);
-      }
-      // Removes the last 'or'.
-      if (end($results) == 'or') {
-        array_pop($results);
-      }
-      $form['field_user_site']['widget']['#states'] = [
-        'invisible' => $results,
-      ];
-    }
-    $form['#validate'][] = '_tide_site_restriction_validation';
-  }
-}
-
-/**
- * Custom validation.
- */
-function _tide_site_restriction_validation(&$form, FormStateInterface $form_state) {
-  if (!isset($form['role_change']['#access']) || !$form['role_change']['#access']) {
-    $values = $form_state->getValue('roles');
-  }
-  else {
-    $values = array_column($form_state->getValue('role_change'), 'target_id');
-  }
-  if ($values) {
-    $roles = Role::loadMultiple($values);
-    if (empty($form_state->getValue('field_user_site'))) {
-      $result = FALSE;
-      foreach ($roles as $role) {
-        if ($role->hasPermission('bypass node access') || $role->hasPermission('administer nodes') || $role->hasPermission('bypass site restriction')) {
-          $result = TRUE;
-        }
-      }
-      if (!$result) {
-        $form_state->setErrorByName('field_user_site', t('Site Restriction field is required.'));
-      }
-    }
-  }
-}
-
-/**
- * Implements hook_preprocess_HOOK().
- */
-function tide_site_restriction_preprocess_fieldset(&$variables) {
-  if (isset($variables['element']['#field_name']) && $variables['element']['#field_name'] == 'field_user_site') {
-    // Adds '*' to field_user_site.
-    $variables['legend']['attributes']->addClass('form-required');
-  }
-}
-
-/**
  * After the user reset the password, redirect them to the home page.
  */
 function tide_site_restriction_form_user_pass_reset_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -365,5 +291,16 @@ function tide_site_restriction_form_alter(&$form, FormStateInterface $form_state
         $form['field_node_primary_site']['widget']['#default_value'] = NULL;
       }
     }
+  }
+}
+
+/**
+ * Implements hook_user_login().
+ */
+function tide_site_restriction_user_login(UserInterface $account) {
+  $site_restriction_helper = \Drupal::service('tide_site_restriction.helper');
+  if (!$site_restriction_helper->getUserSites($account)) {
+    \Drupal::messenger()
+      ->addMessage(t('You need to be assigned a site to access the preview content. please contact to your site administrator.'));
   }
 }

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -304,7 +304,7 @@ function tide_site_restriction_user_login(UserInterface $account) {
   $site_restriction_helper = \Drupal::service('tide_site_restriction.helper');
   if (!$site_restriction_helper->getUserSites($account)) {
     \Drupal::messenger()
-      ->addMessage(t('You need to be assigned a site to access the preview content. Please contact to your site administrator.'));
+      ->addMessage(t('You need to be assigned a site to access the preview content. Please contact your site administrator.'));
   }
 }
 

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -304,7 +304,7 @@ function tide_site_restriction_user_login(UserInterface $account) {
   $site_restriction_helper = \Drupal::service('tide_site_restriction.helper');
   if (!$site_restriction_helper->getUserSites($account)) {
     \Drupal::messenger()
-      ->addMessage(t('You need to be assigned a site to access the preview content. please contact to your site administrator.'));
+      ->addMessage(t('You need to be assigned a site to access the preview content. Please contact to your site administrator.'));
   }
 }
 


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-5317

### Motivation

> Site administrators and administrators can log into the CMS and have access to all sites within content.vic.gov.au. These two roles by-pass the 'roles and permission' module but when these two roles try and preview pages they encounter a 404 message. Preview requires them to be assigned to a site. 

### Changes
1. Removed custom validation
2. changed the field to the `required` field
3. Added a logged in message to notify users who doesn't have a site need to be assigned a site.
![image](https://user-images.githubusercontent.com/8788145/124052372-a03d8000-da61-11eb-8952-4a9181bae273.png)
