### PR TITLE
[SDPA-4354] Adds the sub-site filter to the view

### DIFF
--- a/src/Plugin/views/filter/SubSitesFilter.php
+++ b/src/Plugin/views/filter/SubSitesFilter.php
@@ -86,7 +86,7 @@ class SubSitesFilter extends ManyToOne {
   }
 
   /**
-   * generates the options.
+   * Generates the options.
    *
    * @return array
    *   An array of tid and its label.
@@ -108,7 +108,7 @@ class SubSitesFilter extends ManyToOne {
   }
 
   /**
-   * builds the query.
+   * Builds the query.
    */
   public function query() {
     if (!empty($this->value)) {

--- a/src/Plugin/views/filter/SubSitesFilter.php
+++ b/src/Plugin/views/filter/SubSitesFilter.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Drupal\tide_site_restriction\Plugin\views\filter;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\taxonomy\TermStorageInterface;
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
+use Drupal\views\Plugin\views\filter\ManyToOne;
+use Drupal\views\ViewExecutable;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filters by sub-sites.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("sub_sites_filter")
+ */
+class SubSitesFilter extends ManyToOne {
+
+  /**
+   * The current display.
+   *
+   * @var string
+   *   The current display of the view.
+   */
+  protected $currentDisplay;
+
+  /**
+   * The term storage.
+   *
+   * @var \Drupal\taxonomy\TermStorageInterface
+   */
+  protected $termStorage;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a SubSitesFilter object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\taxonomy\TermStorageInterface $term_storage
+   *   The term storage.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, TermStorageInterface $term_storage, AccountInterface $current_user = NULL) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->termStorage = $term_storage;
+    $current_user = \Drupal::service('current_user');
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')->getStorage('taxonomy_term'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
+    parent::init($view, $display, $options);
+    $this->valueTitle = t('Filter by sites');
+    $this->definition['options callback'] = [$this, 'generateOptions'];
+    $this->currentDisplay = $view->current_display;
+  }
+
+  /**
+   * generates the options.
+   *
+   * @return array
+   *   An array of tid and its label.
+   */
+  public function generateOptions() {
+    $tree = $this->termStorage->loadTree('sites', 0, NULL, TRUE);
+    $options = [];
+    if ($tree) {
+      foreach ($tree as $term) {
+        if (!$term->isPublished() && !$this->currentUser->hasPermission('administer taxonomy')) {
+          continue;
+        }
+        $choice = new \stdClass();
+        $choice->option = [$term->id() => str_repeat('-', $term->depth) . \Drupal::service('entity.repository')->getTranslationFromContext($term)->label()];
+        $options[] = $choice;
+      }
+    }
+    return $options;
+  }
+
+  /**
+   * builds the query.
+   */
+  public function query() {
+    if (!empty($this->value)) {
+      $configuration = [
+        'table' => 'node__field_node_site',
+        'type' => 'INNER',
+        'field' => 'entity_id',
+        'left_table' => 'node_field_data',
+        'left_field' => 'nid',
+        'operator' => '=',
+      ];
+      $join = Views::pluginManager('join')->createInstance('standard', $configuration);
+      $this->query->addRelationship('node__field_node_site', $join, 'node_field_data');
+      $this->query->addWhere('AND', 'node__field_node_site.field_node_site_target_id', $this->value, 'IN');
+    }
+  }
+
+}

--- a/tide_site_restriction.install
+++ b/tide_site_restriction.install
@@ -50,3 +50,76 @@ function tide_site_restriction_install() {
     $role->save();
   }
 }
+
+/**
+ * Adds sub_sites_filter filter.
+ */
+function tide_site_restriction_update_8001() {
+  $value = [
+    'id' => 'sub_sites_filter',
+    'table' => 'node_field_data',
+    'field' => 'sub_sites_filter',
+    'relationship' => 'none',
+    'group_type' => 'group',
+    'admin_label' => '',
+    'operator' => 'or',
+    'value' => [],
+    'group' => 1,
+    'exposed' => TRUE,
+    'expose' => [
+      'operator_id' => 'sub_sites_filter_op',
+      'label' => 'Sub-Sites',
+      'description' => '',
+      'use_operator' => FALSE,
+      'operator' => 'sub_sites_filter_op',
+      'operator_limit_selection' => FALSE,
+      'operator_list' => [],
+      'identifier' => 'sub_sites_filter',
+      'required' => FALSE,
+      'remember' => FALSE,
+      'multiple' => TRUE,
+      'remember_roles' => [
+        'authenticated' => 'authenticated',
+        'anonymous' => '0',
+        'administrator' => '0',
+        'approver' => '0',
+        'site_admin' => '0',
+        'editor' => '0',
+        'previewer' => '0',
+      ],
+      'reduce' => 0,
+    ],
+    'is_grouped' => FALSE,
+    'group_info' => [
+      'label' => '',
+      'description' => '',
+      'identifier' => '',
+      'optional' => TRUE,
+      'widget' => 'select',
+      'multiple' => FALSE,
+      'remember' => FALSE,
+      'default_group' => 'All',
+      'default_group_multiple' => [],
+      'group_items' => [],
+    ],
+    'reduce_duplicates' => 0,
+    'entity_type' => 'node',
+    'plugin_id' => 'sub_sites_filter',
+  ];
+  $view_config = \Drupal::service('config.factory')
+    ->getEditable('views.view.summary_contents_filters');
+  $display = $view_config->get('display');
+  if (isset($display['default']['display_options']['filters']['field_node_site_target_id'])) {
+    $new_filters = [];
+    foreach ($display['default']['display_options']['filters'] as $key => $detail) {
+      if ($key === 'field_node_site_target_id') {
+        $new_filters['sub_sites_filter'] = $value;
+        continue;
+      }
+      $new_filters[$key] = $detail;
+    }
+    $display['default']['display_options']['filters'] = $new_filters;
+    $view_config->set('display', $display);
+    $view_config->save();
+  }
+}

--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -102,7 +102,7 @@ function tide_site_restriction_user_presave(UserInterface $user) {
 function tide_site_restriction_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
   // Pre-select user sites in Summary Content admin view.
   $view_ids = ['summary_contents_filters', 'media'];
-  $display_ids = ['page_1' => 'field_node_site_target_id', 'media_page_list' => 'field_media_site_target_id'];
+  $display_ids = ['page_1' => 'sub_sites_filter', 'media_page_list' => 'field_media_site_target_id'];
   $account = \Drupal::currentUser();
   foreach ($view_ids as $view_id) {
     if ($view->id() == $view_id) {
@@ -143,7 +143,7 @@ function tide_site_restriction_form_views_exposed_form_alter(&$form, FormStateIn
   // Enable Select2 to Site filter of Content Admin view.
   $form_ids = [
     'views-exposed-form-media-media-page-list' => 'field_media_site_target_id',
-    'views-exposed-form-summary-contents-filters-page-1' => 'field_node_site_target_id',
+    'views-exposed-form-summary-contents-filters-page-1' => 'sub_sites_filter',
   ];
   foreach ($form_ids as $form_id => $filter) {
     if (!empty($form['#id']) && $form['#id'] == $form_id) {
@@ -366,4 +366,19 @@ function tide_site_restriction_form_alter(&$form, FormStateInterface $form_state
       }
     }
   }
+}
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function tide_site_restriction_views_data_alter(array &$data) {
+  $data['node_field_data']['sub_sites_filter'] = [
+    'title' => t('Sub-sites'),
+    'filter' => [
+      'title' => t('Sub sites filter'),
+      'help' => t('Provides a custom filter for admin/content view.'),
+      'field' => 'nid',
+      'id' => 'sub_sites_filter',
+    ],
+  ];
 }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4354

### Motivation

After the debugging, I noticed that the view uses `join` multiple tables to filter and get results, which has a low performance when we doing something like filtering by sub sites. 
``` mysql
SELECT node_field_revision.changed AS node_field_revision_changed, node_field_data.nid AS nid, users_field_data_node_field_data.uid AS users_field_data_node_field_data_uid
FROM
node_field_data node_field_data
INNER JOIN users_field_data users_field_data_node_field_data ON node_field_data.uid = users_field_data_node_field_data.uid
LEFT JOIN node__field_node_site node__field_node_site_value_0 ON node_field_data.nid = node__field_node_site_value_0.entity_id AND node__field_node_site_value_0.field_node_site_target_id = '692'
LEFT JOIN node__field_node_site node__field_node_site_value_1 ON node_field_data.nid = node__field_node_site_value_1.entity_id AND node__field_node_site_value_1.field_node_site_target_id = '693'
LEFT JOIN node__field_node_site node__field_node_site_value_2 ON node_field_data.nid = node__field_node_site_value_2.entity_id AND node__field_node_site_value_2.field_node_site_target_id = '689'
INNER JOIN node_field_revision node_field_revision ON node_field_data.vid = node_field_revision.vid
WHERE ((node__field_node_site_value_0.field_node_site_target_id = '692') OR (node__field_node_site_value_1.field_node_site_target_id = '693') OR (node__field_node_site_value_2.field_node_site_target_id = '689')) AND ((node_field_data.status = 1 OR (node_field_data.uid = 8992 AND 8992 <> 0 AND 1 = 1) OR 1 = 1 OR 1 = 1))
ORDER BY node_field_revision_changed DESC
LIMIT 50 OFFSET 0
```
above is a default query when you doing filtering by sites 692, 693, 689. `node__field_node_site`  table joined 3 times, when user has more than 30 sites the join will be happing 30 times.

so proposed solution direction will be using IN instead of multiple joins.

ideally, query will be basically rewrite to 
```mysql
SELECT node_field_revision.changed AS node_field_revision_changed, node_field_data.nid AS nid, users_field_data_node_field_data.uid AS users_field_data_node_field_data_uid
FROM
node_field_data node_field_data
INNER JOIN users_field_data users_field_data_node_field_data ON node_field_data.uid = users_field_data_node_field_data.uid
LEFT JOIN node__field_node_site node__field_node_site_value_0 ON node_field_data.nid = node__field_node_site_value_0.entity_id AND node__field_node_site_value_0.field_node_site_target_id in (693, 692,689)
INNER JOIN node_field_revision node_field_revision ON node_field_data.vid = node_field_revision.vid
WHERE ((node__field_node_site_value_0.field_node_site_target_id in (693, 692,689)) AND ((node_field_data.status = 1 OR (node_field_data.uid = 8992 AND 8992 <> 0 AND 1 = 1) OR 1 = 1 OR 1 = 1)))
ORDER BY node_field_revision_changed DESC
LIMIT 50 OFFSET 0;
```
which needs building a custom view filter by implementing many to one relationship.

### Changes
1. Adds a custom filter to `admin/content` view as default one doesn't work when user has more than 30 sites assigned.