### PR TITLE
[SW-1425] Remove tide_publiction dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
     "require": {
         "dpc-sdp/tide_core": "^3.0.0",
         "dpc-sdp/tide_site": "^3.0.0",
-        "dpc-sdp/tide_publication": "^3.0.0",
         "drupal/select2": "^1.7",
         "oomphinc/composer-installers-extender": "^2.0",
         "select2/select2": "^4.0",
         "drupal/form_options_attributes": "^1.0"
     },
     "suggest": {
-        "dpc-sdp/tide_api:^3.0.0": "Allows to use Drupal in headless mode"
+        "dpc-sdp/tide_api:^3.0.0": "Allows to use Drupal in headless mode",
+        "dpc-sdp/tide_publication:^3.0.0": "Allows to use publication content type"
     },
     "repositories": {
         "drupal": {

--- a/tide_site_restriction.info.yml
+++ b/tide_site_restriction.info.yml
@@ -6,7 +6,6 @@ core_version_requirement: ^8.9 || ^9
 dependencies:
   - dpc-sdp:tide_core
   - dpc-sdp:tide_site
-  - dpc-sdp:tide_publication
   - drupal:select2
   - drupal:form_options_attributes
 config_devel:


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SW-1425

### Motivation
1. tide_publiction will be enabled with tide_site_restction, which is not wanted behaviour. 

### Changes
1. moves tide_publiction dependency to `suggest` key in composer.json
2. removes `dpc-sdp:tide_publication` from `tide_site_restriction.info.yml`