### PR TITLE
[SDPA-6261] Fixes a route permission issue

### DIFF
--- a/src/Access/SiteAccessRouteCheck.php
+++ b/src/Access/SiteAccessRouteCheck.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\tide_site_restriction\Access;
+
+use Drupal\Core\Access\AccessResultNeutral;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\node\NodeInterface;
+use Drupal\tide_site_restriction\Helper;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Checks access for routers when tide_site_restriction module gets enabled.
+ */
+class SiteAccessRouteCheck implements AccessInterface {
+
+  /**
+   * Tide site restriction helper.
+   *
+   * @var \Drupal\tide_site_restriction\Helper
+   */
+  protected $helper;
+
+  /**
+   * Constructs a new SiteAccessRouteCheck.
+   *
+   * @param \Drupal\tide_site_restriction\Helper $helper
+   *   Tide site restriction helper.
+   */
+  public function __construct(Helper $helper) {
+    $this->helper = $helper;
+  }
+
+  /**
+   * Check if the user can access the route attached to a node.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   A result.
+   */
+  public function access(AccountInterface $account, NodeInterface $node) {
+    if ($this->helper->canBypassRestriction($account)) {
+      return AccessResult::allowed()
+        ->addCacheableDependency($node)
+        ->addCacheTags(['site_restriction'])
+        ->cachePerUser();
+    }
+    // Computes the result.
+    $result = tide_site_compute_access($account, $node, $this->helper);
+    if (!$result) {
+      throw new AccessDeniedHttpException();
+    }
+    // Abstaining will generate 'denies access'.
+    if ($result instanceof AccessResultNeutral) {
+      return AccessResult::allowed()
+        ->addCacheableDependency($node)
+        ->addCacheTags(['site_restriction'])
+        ->cachePerUser();
+    }
+    return $result;
+  }
+
+}

--- a/src/EventSubscriber/TideSiteRestrictionRouterAlter.php
+++ b/src/EventSubscriber/TideSiteRestrictionRouterAlter.php
@@ -2,11 +2,7 @@
 
 namespace Drupal\tide_site_restriction\EventSubscriber;
 
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\RouteSubscriberBase;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\node\NodeInterface;
-use Drupal\user\Entity\User;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -21,29 +17,11 @@ class TideSiteRestrictionRouterAlter extends RouteSubscriberBase {
    */
   protected function alterRoutes(RouteCollection $collection) {
     if ($route = $collection->get('entity.node.entity_hierarchy_reorder')) {
-      $route->setRequirement('_custom_access', '\Drupal\tide_site_restriction\EventSubscriber\TideSiteRestrictionRouterAlter::childPageAccess');
+      $route->setRequirement('_site_access_route_check', 'TRUE');
     }
     if ($route = $collection->get('quick_node_clone.node.quick_clone')) {
-      $route->setRequirement('_custom_access', '\Drupal\tide_site_restriction\EventSubscriber\TideSiteRestrictionRouterAlter::childPageAccess');
+      $route->setRequirement('_site_access_route_check', 'TRUE');
     }
-  }
-
-  /**
-   * Permission check for node's children pages.
-   */
-  public static function childPageAccess(AccountInterface $account, NodeInterface $node) {
-    /** @var \Drupal\tide_site_restriction\Helper $helper */
-    $helper = \Drupal::service('tide_site_restriction.helper');
-    if ($helper->canBypassRestriction($account)) {
-      return AccessResult::allowed()
-        ->addCacheableDependency($node)
-        ->addCacheTags(['site_restriction'])
-        ->cachePerUser();
-    }
-    return AccessResult::allowedIf($helper->hasEntitySitesAccess($node, $helper->getUserSites(User::load($account->id()))))
-      ->addCacheableDependency($node)
-      ->addCacheTags(['site_restriction'])
-      ->cachePerUser();
   }
 
 }

--- a/tide_site_restriction.services.yml
+++ b/tide_site_restriction.services.yml
@@ -8,3 +8,8 @@ services:
     class: Drupal\tide_site_restriction\EventSubscriber\TideSiteRestrictionRouterAlter
     tags:
       - { name: event_subscriber }
+  tide_site_restriction.site_access_route_check:
+    class: \Drupal\tide_site_restriction\Access\SiteAccessRouteCheck
+    arguments: ['@tide_site_restriction.helper']
+    tags:
+      - { name: access_check, applies_to: _site_access_route_check }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-6261

### Fix
1. `_custom_access` will override all other requirements; we should remove it.
2. we add a custom permission check that applies to the route.
3. there is an outstanding core `bug` in an open PR https://www.drupal.org/project/drupal/issues/2991698#comment-13424914, which is why, in this case, I recognise `AccessResultNeutral == AccessResult::allowed` https://github.com/dpc-sdp/tide_site_restriction/pull/34/files#diff-8c9d9f1b1cae2e447563f18d9e661c240c17410aef29a266af7841daaaeb3e5aR59
    - I don't want to include this patch as I don't want to take risks that may affect other modules.
