### PR TITLE
[SDPA-6205] Cloning site section not included in cloned content.

### DIFF
--- a/tide_site_restriction.module
+++ b/tide_site_restriction.module
@@ -19,7 +19,6 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\node\Entity\Node;
 use Drupal\tide_site_restriction\Helper;
 use Drupal\user\Entity\Role;
-use Drupal\node\Entity\NodeType;
 
 /**
  * Implements hook_entity_field_access().
@@ -328,20 +327,6 @@ function tide_site_restriction_entity_operation_alter(array &$operations, Entity
     if (!$user_can_bypass_restriction) {
       if (!$site_restriction_helper->hasEntitySitesAccess($entity, $user_sites)) {
         unset($operations['quick_clone']);
-      }
-    }
-  }
-}
-
-/**
- * Implements hook_form_alter().
- */
-function tide_site_restriction_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $node_types = NodeType::loadMultiple();
-  foreach ($node_types as $node_type => $obj) {
-    if ($form_id == 'node_' . $node_type . '_quick_node_clone_form') {
-      if (isset($form['field_node_site']) && isset($form['field_node_primary_site'])) {
-        $form['field_node_site']['widget']['#default_value'] = [];
       }
     }
   }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-vic.atlassian.net/browse/SDPAP-6205

### Info
Similar JIRA: https://digital-engagement.atlassian.net/browse/SDPA-6161 and the [bug](https://github.com/dpc-sdp/tide_site_restriction/pull/33) fix for issue where primary site was empty and couldn't clone page for editor without primary site. This fixes the site sections permission so site permissions are retained when cloning a node.

### Changed

1. Fixed to keep site sections values intact when cloning page.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->

Dev test findings with attachment.
1. Tested a few scenarios with Editor site section restrictions.
2. Retestest previous fix scenarios to ensure behaviour is working as expected.
[SDPA-6205-Cloning-site-sections-not-included-in-cloned-content.xlsx](https://github.com/dpc-sdp/content-reference-sdp-vic-gov-au/files/8988441/SDPA-6205-Cloning-site-sections-not-included-in-cloned-content.xlsx)
