### PR TITLE
[SDPAP-6697] Add 2 layers of permissions to views

### DIFF
--- a/src/Access/SiteAccessRouteCheck.php
+++ b/src/Access/SiteAccessRouteCheck.php
@@ -8,7 +8,9 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\node\NodeInterface;
 use Drupal\tide_site_restriction\Helper;
+use Drupal\user\Entity\User;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Route;
 
 /**
  * Checks access for routers when tide_site_restriction module gets enabled.
@@ -63,6 +65,34 @@ class SiteAccessRouteCheck implements AccessInterface {
         ->cachePerUser();
     }
     return $result;
+  }
+
+  /**
+   * Check if the user can access the route attached to a view.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account.
+   * @param \Symfony\Component\Routing\Route $route
+   *   The node.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   A result.
+   */
+  public function viewsAccess(AccountInterface $account, Route $route) {
+    if ($this->helper->canBypassRestriction($account)) {
+      return AccessResult::allowed();
+    }
+    $permission = $route->getOption('_views_permission');
+    $sites = array_keys(array_filter($route->getOption('_views_sites')));
+    if (empty($sites)) {
+      return AccessResult::neutral();
+    }
+    $user_sites = $this->helper->getUserSites(User::load($account->id()));
+    $assigned_site = array_intersect_key($user_sites, array_flip($sites));
+    if ($account->hasPermission($permission) && !empty($assigned_site)) {
+      return AccessResult::allowed();
+    }
+    return AccessResult::forbidden();
   }
 
 }

--- a/src/Plugin/views/access/SiteBasedPermission.php
+++ b/src/Plugin/views/access/SiteBasedPermission.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\tide_site_restriction\Plugin\views\access;
+
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\tide_site_restriction\Helper;
+use Drupal\user\Entity\User;
+use Drupal\user\PermissionHandlerInterface;
+use Drupal\user\Plugin\views\access\Permission;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Access plugin that provides site based permission access control.
+ *
+ * @ingroup views_access_plugins
+ *
+ * @ViewsAccess(
+ *   id = "site_based_permission",
+ *   title = @Translation("Site based permission"),
+ *   help = @Translation("Access will be granted to users with 2 layers permission.")
+ * )
+ */
+class SiteBasedPermission extends Permission {
+
+  /**
+   * The site helper.
+   *
+   * @var \Drupal\tide_site_restriction\Helper
+   */
+  protected $helper;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, PermissionHandlerInterface $permission_handler, ModuleHandlerInterface $module_handler, Helper $helper) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $permission_handler, $module_handler);
+    $this->helper = $helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('user.permissions'),
+      $container->get('module_handler'),
+      $container->get('tide_site_restriction.helper')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access(AccountInterface $account) {
+    if ($this->helper->canBypassRestriction($account)) {
+      return parent::access($account);
+    }
+    $sites = array_keys(array_filter($this->options['sites']));
+    if (empty($sites)) {
+      return parent::access($account);
+    }
+    $user_sites = $this->helper->getUserSites(User::load($account->id()));
+    $assigned_site = array_intersect_key($user_sites, array_flip($sites));
+    return $account->hasPermission($this->options['perm']) && !empty($assigned_site);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+    $tree = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('sites', 0, 1);
+    foreach ($tree as $item) {
+      $options[$item->tid] = $item->name;
+    }
+    $form['sites'] = [
+      '#type' => 'checkboxes',
+      '#options' => $options,
+      '#title' => $this->t('Sites'),
+      '#default_value' => $this->options['sites'],
+      '#description' => $this->t('Only users with the selected site(s) will be able to access this display.'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRouteDefinition(Route $route) {
+    $route->setRequirement('_custom_access', 'tide_site_restriction.site_access_route_check:viewsAccess');
+    $route->setOption('_views_sites', $this->options['sites']);
+    $route->setOption('_views_permission', $this->options['perm']);
+  }
+
+}

--- a/src/Plugin/views/access/SiteBasedPermission.php
+++ b/src/Plugin/views/access/SiteBasedPermission.php
@@ -76,6 +76,7 @@ class SiteBasedPermission extends Permission {
   public function buildOptionsForm(&$form, FormStateInterface $form_state) {
     parent::buildOptionsForm($form, $form_state);
     $tree = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('sites', 0, 1);
+    $options = [];
     foreach ($tree as $item) {
       $options[$item->tid] = $item->name;
     }


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-6697

### Motivations
1. site based permissions haven't applied to the views route.
2. this patch provides the site builders with an opportunity to apply both drupal permissions and site-based permissions to a view.
3. this is not mandatory, so I will not provide a config update.


### usage
- go to the view.
- Click `access` setting under `PAGE SETTINGS` section.
- select `Site based permission`
![image](https://user-images.githubusercontent.com/8788145/195771845-14f7a8e0-91b1-42d8-a999-2959bc3f3306.png)

see below
![image](https://user-images.githubusercontent.com/8788145/195271721-3a2fb4d1-4ce4-4766-9f2e-4ce44216bbbd.png)
