### PR TITLE
[SDPAP-7084] Updated method to remove duplicate values from two dimensional array.

### DIFF
--- a/src/Plugin/Field/FieldWidget/TideSiteRestrictionFieldWidget.php
+++ b/src/Plugin/Field/FieldWidget/TideSiteRestrictionFieldWidget.php
@@ -191,7 +191,7 @@ class TideSiteRestrictionFieldWidget extends OptionsButtonsWidget implements Con
       }
       $options[] = ['target_id' => $parentSiteId];
     }
-    return array_map('unserialize', array_unique(array_map('serialize', array_merge($results, $options))));
+    return array_unique(array_merge($results, $options), SORT_REGULAR);
   }
 
   /**


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-7084

### Issue
`return array_map('unserialize', array_unique(array_map('serialize', array_merge($results, $options))));`
the statement above was not returning unique values. The $options gets the parentsSiteId and somehow when 'serialize' is used, it serializes the values from $results, $options as a different data type. e.g 4 and "4". so when array_unique was run, it wasn't removing the 4 and after 'unserialize' it creates duplicate site ids. Then these sites ids gets passed to field_node_site and when it tries to create the node access record [here](https://github.com/dpc-sdp/tide_site_restriction/blob/develop/tide_site_restriction.module#L178) while saving the node, because of duplicate values it throws db error.

serialize have these kind of issue when converting values, so instead of that there is a better way to remove duplicate values from two dimensional array. See the 2nd post from here with most votes and comments, not the accepted one. - https://stackoverflow.com/questions/307674/how-to-remove-duplicate-values-from-a-multi-dimensional-array-in-php

### Changes
Change method to remove duplicate values from two dimensional array

Bug test link - 
- https://nginx-php.pr-1477.content-vic.sdp4.sdp.vic.gov.au/
- https://nginx-php.pr-130.museum-content-vicpol-vic-gov-au.sdp4.sdp.vic.gov.au/
