### PR TITLE
Added property initialisation.

### DIFF
--- a/src/Plugin/Field/FieldWidget/TideSiteRestrictionFieldWidget.php
+++ b/src/Plugin/Field/FieldWidget/TideSiteRestrictionFieldWidget.php
@@ -68,6 +68,7 @@ class TideSiteRestrictionFieldWidget extends OptionsButtonsWidget implements Con
     $this->currentUser = $currentUser;
     $this->helper = $helper;
     $this->moderationInformation = $moderation_information;
+    $this->multiple = !empty($settings['multiple_values']);
   }
 
   /**


### PR DESCRIPTION
### Issue
When a user with multiple site site permission tries to edit and save a page it throws error.
Error message - 
`Error: Typed property Drupal\Core\Field\Plugin\Field\FieldWidget\OptionsWidgetBase::$multiple must not be accessed before initialization in Drupal\tide_site_restriction\Plugin\Field\FieldWidget\TideSiteRestrictionFieldWidget->massageFormValues() (line 142 of /app/docroot/modules/contrib/tide_site_restriction/src/Plugin/Field/FieldWidget/TideSiteRestrictionFieldWidget.php).`

### Reason
https://php.watch/versions/8.2/dynamic-properties-deprecated
The update from php 8.1 to 8.2

### Solution
Initialize the property in the constructor.

Currently using it as a dev reference in the content-vic hotfix branch. Will release it later for other projects when hotfix gets tested and the issue is resolved.